### PR TITLE
Support connect to hidden networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Connects to the specified network.
 - **options.ssid**                   - Specifies the network name.
 - **options.psk**                    - Specifies the password.
 - **options.timeout**                - Specifies the number of milliseconds to wait for connection. Default is 60 seconds (60000).
+- **options.hidden**                 - Should be set to `true` if the network is hidden.
 
 ````javascript
 var Wifi = require('rpi-wifi-connection');

--- a/src/wifi-connection.js
+++ b/src/wifi-connection.js
@@ -151,6 +151,7 @@ module.exports = class WiFiConnection {
         var ssid     = options.ssid;
         var password = options.psk;
         var timeout  = options.timeout;
+        var hidden   = options.hidden;
 
         function delay(ms) {
             return new Promise((resolve, reject) => {
@@ -175,7 +176,11 @@ module.exports = class WiFiConnection {
 
         function setNetwork(id, name, value) {
             debug(sprintf('Setting variable %s=%s for network %d.', name, value, id));
-            return self.wpa_cli(sprintf('set_network %d %s \'"%s"\'', id, name, value), '^OK');
+            if (typeof value === 'number') {
+                return self.wpa_cli(sprintf('set_network %d %s %d', id, name, value), '^OK');
+            } else {
+                return self.wpa_cli(sprintf('set_network %d %s \'"%s"\'', id, name, value), '^OK');
+            }
         }
 
 
@@ -282,6 +287,9 @@ module.exports = class WiFiConnection {
             })
             .then(() => {
                 return (isString(password) ? setNetwork(networkID, 'psk', password) : Promise.resolve());
+            })
+            .then(() => {
+                return hidden ? setNetwork(networkID, 'scan_ssid', 1) : Promise.resolve();
             })
             .then(() => {
                 return selectNetwork(networkID);


### PR DESCRIPTION
Preface: I don't know if this is still maintained or this repo accepts PRs, but I'll let you know that this repo saved me a lot of time today! However, I need to connect to a hidden network in my use case, so a little modification is needed.

This PR adds support to connect to hidden networks by introducing `hidden` options.

If `hidden` is enabled, it will execute the `wpa_cli` command `set_network <id> scan_ssid 1`.
